### PR TITLE
Use golang:1.7

### DIFF
--- a/moira-go/Dockerfile
+++ b/moira-go/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.6
+FROM golang:1.7
 
 # http://moira.readthedocs.org/en/latest/quickstart.html
 


### PR DESCRIPTION
For me, it's the only way this would build.

I don't know anything about Go, but it seems to be related to how the `context` package is imported, whatever that means.